### PR TITLE
Persist collapsed files

### DIFF
--- a/client.js
+++ b/client.js
@@ -12,17 +12,32 @@ const link = $("<a />").attr({
   "rel": "nofollow"
 }).html(icon);
 
+const namespace = window.location.pathname.replace(/\/(files|commits)?\/?$/, "");
+const store = new Store(namespace);
+
 function decorateFiles() {
   $(".file").forEach(file => decorateFile(file));
 }
 
 function decorateFile(file) {
   if ($(file).find(".pid-collapse").length === 0) {
+    const fileName = $(file).find(".file-header").data("path");
     const fileContent = $(file).find(".js-file-content");
+    store.getCollapsed(fileName).then(collapsed => {
+      if (collapsed) {
+        fileContent.hide();
+      }
+    });
     const fileLink = link.clone();
     fileLink.click(event => {
       event.preventDefault();
-      fileContent.toggle();
+      if (fileContent.css("display") === "none") {
+        fileContent.show();
+        store.setUncollapsed(fileName);
+      } else {
+        fileContent.hide();
+        store.setCollapsed(fileName);
+      }
     });
     $(file).find(".file-actions").append(fileLink);
   }

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 2,
   "name": "Pipe it Down",
   "version": "0.0.1",
+  "permissions": ["storage"],
   "content_scripts": [
     {
       "matches": [
@@ -9,6 +10,7 @@
       ],
       "js": [
         "zepto.min.js",
+        "store.js",
         "client.js"
       ]
     }

--- a/store.js
+++ b/store.js
@@ -1,0 +1,44 @@
+class Store {
+  constructor(namespace) {
+    this.namespace = namespace;
+  }
+
+  all() {
+    return new Promise(resolve =>
+      chrome.storage.local.get(
+        this.namespace,
+        data => resolve(this._deserialize(data))
+      )
+    );
+  }
+
+  getCollapsed(key) {
+    return this._get(key).then(data => !!data);
+  }
+
+  setCollapsed(key) {
+    return this.all().then(data => {
+      data[key] = Date.now();
+      this._set(data);
+    });
+  }
+
+  setUncollapsed(key) {
+    return this.all().then(data => {
+      delete data[key];
+      this._set(data);
+    });
+  }
+
+  _get(key) {
+    return this.all().then(data => data[key]);
+  }
+
+  _set(data) {
+    chrome.storage.local.set({[this.namespace]: data});
+  }
+
+  _deserialize(data) {
+    return data[this.namespace] || {};
+  }
+}


### PR DESCRIPTION
Uses local (extension) storage to track which files on which pages have
been collapsed. This information is used to automatically collapse files
when revisiting a previously viewed page.

Introduces a Store object to encapsulate interactions with the local
storage. An unexpected behaviour of the local storage, is that fetching
a key will return an object _including_ that key, whose value is the
value you actually wanted. E.g.

```
chrome.storage.local.get("myKey", data => {
 // data is { "myKey": "stuff I care about" }
})
```

The `_deserialize` "private" method deals with this. Is there a more
appropriate name for what it's doing?

![persist-collapse](https://cloud.githubusercontent.com/assets/72176/23050201/a7ac1d28-f475-11e6-8e61-9e08c563e71d.gif)
