### PR TITLE
Extract File class

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,45 +1,14 @@
-const tooltip = "Collapse this file";
-
-const link = $("<a />").attr({
-  "aria-label": tooltip,
-  "class": "btn-octicon tooltipped tooltipped-nw pid-collapse",
-  "data-skip-pjax": "",
-  "href": "#",
-  "rel": "nofollow"
-}).html(icons.hide);
-
 const github = new GitHub({ pathname: window.location.pathname });
 const store = new Store(github.pullRequestPath());
 
 function decorateFiles() {
-  $(".file").forEach(file => decorateFile(file));
-}
-
-function decorateFile(file) {
-  if ($(file).find(".pid-collapse").length === 0) {
-    const fileName = $(file).find(".file-header").data("path");
-    const fileContent = $(file).find(".js-file-content");
-    const fileLink = link.clone();
-    store.getCollapsed(fileName).then(collapsed => {
-      if (collapsed) {
-        fileLink.html(icons.show);
-        fileContent.hide();
-      }
+  github.files().forEach(element => {
+    const file = new File( {
+      $element: $(element),
+      store: store
     });
-    fileLink.click(event => {
-      event.preventDefault();
-      if (fileContent.css("display") === "none") {
-        fileContent.show();
-        store.setUncollapsed(fileName);
-        fileLink.html(icons.hide);
-      } else {
-        fileContent.hide();
-        store.setCollapsed(fileName);
-        fileLink.html(icons.show);
-      }
-    });
-    $(file).find(".file-actions").append(fileLink);
-  }
+    file.decorate();
+  });
 }
 
 if (github.isPullRequest()) {

--- a/src/file.js
+++ b/src/file.js
@@ -1,0 +1,84 @@
+const collapseTooltip = "Collapse this file";
+const expandTooltip = "Expand this file";
+
+const linkTemplate = $("<a />").attr({
+  "aria-label": collapseTooltip,
+  "class": "btn-octicon tooltipped tooltipped-nw pid-collapse",
+  "data-skip-pjax": "",
+  "href": "#",
+  "rel": "nofollow"
+}).html(icons.hide);
+
+class File {
+  constructor({ $element, store }) {
+    this.$element = $element;
+    this.store = store;
+    this.toggleLink = linkTemplate.clone();
+  }
+
+  decorate() {
+    if (!this._isDecorated()) {
+      this._hideIfPreviouslyHidden();
+      this._registerClickEvent();
+      this._insertDomLink();
+    }
+  }
+
+  _hideIfPreviouslyHidden() {
+    store.getCollapsed(this._fileName()).then(collapsed => {
+      if (collapsed) {
+        this._hide();
+      }
+    });
+  }
+
+  _registerClickEvent() {
+    this.toggleLink.click(event => {
+      event.preventDefault();
+
+      if (this._isHidden()) {
+        this._show();
+      } else {
+        this._hide();
+      }
+    });
+  }
+
+  _insertDomLink() {
+    this.$element.find(".file-actions").append(this.toggleLink);
+  }
+
+  _isDecorated() {
+    return this.$element.find(".pid-collapse").length > 0;
+  }
+
+  _fileName() {
+    return this.$element.find(".file-header").data("path");
+  }
+
+  _fileContent() {
+    return this.$element.find(".js-file-content");
+  }
+
+  _isHidden() {
+    return this._fileContent().css("display") === "none";
+  }
+
+  _hide() {
+    this._fileContent().hide();
+    this.toggleLink.html(icons.show);
+    this.toggleLink.attr("aria-label", expandTooltip);
+    this.store.setCollapsed(this._fileName());
+  }
+
+  _show() {
+    this._fileContent().show();
+    this.toggleLink.html(icons.hide);
+    this.toggleLink.attr("aria-label", collapseTooltip);
+    this.store.setUncollapsed(this._fileName());
+  }
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = File
+}

--- a/src/github.js
+++ b/src/github.js
@@ -3,6 +3,10 @@ class GitHub {
     this.pathname = pathname;
   }
 
+  files() {
+    return $(".file");
+  }
+
   isPullRequest() {
     return !!this.pullRequestPath();
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,6 +13,7 @@
         "github.js",
         "icons.js",
         "store.js",
+        "file.js",
         "client.js"
       ]
     }


### PR DESCRIPTION
Cleans up client.js so hopefully the flow of things is more readable.
Moves all the decorating logic to a File class.

Also updates the tool tip when a file's visibility is changed.

![tooltip](https://cloud.githubusercontent.com/assets/72176/23088219/3925b4da-f52f-11e6-94a5-476ad2a95060.gif)
